### PR TITLE
Removed data= options

### DIFF
--- a/archlabs-installer
+++ b/archlabs-installer
@@ -594,8 +594,7 @@ select_filesystem() {
         "ext4")
             FS="mkfs.ext4 -q" CHK_NUM=8
             fs_opts=(
-            "data=journal" "data=writeback" dealloc
-            discard noacl noatime nobarrier nodelalloc
+            dealloc discard noacl noatime nobarrier nodelalloc
             )
             ;;
         "f2fs")


### PR DESCRIPTION
The *data=journal* & *data=writeback* options are for ext3 rather than ext4 and can cause errors on boot.

See https://bbs.archlinux.org/viewtopic.php?pid=1200961#p1200961 & https://forum.archlabslinux.com/t/failed-to-start-remount-root-and-kernel-file-systems/468